### PR TITLE
README.md mention the Regexp::IPv6 dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,5 +73,12 @@ See who has downloaded me:
 
       select * FROM logs WHERE request='/etch/pool/main/a/asql/asql_0.6-1_all.deb';
 
+
+Dependencies
+------------
+
+For parsing IPv6 log entries the Regexp::IPv6 module is required.
+
+
 Steve
 --


### PR DESCRIPTION
Without the Regexp::IPv6 module IPv6 entries cannot be parsed.

Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>