### PR TITLE
Add a phony target test and its alias check for consistency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ VERSION     = 1.7
 BASE        = asql
 
 
+.PHONY: test
 
 stubb:
 	@echo "Valid targets are"
@@ -51,6 +52,8 @@ release: clean commands
 	rm -rf $(DIST_PREFIX)/$(BASE)-$(VERSION)
 	gpg --armour --detach-sign $(BASE)-$(VERSION).tar.gz
 	echo $(VERSION) > .version
+
+check: test
 
 test:
 	prove --shuffle t/


### PR DESCRIPTION
Declare `test` as a phony target and also add `check` target as its alias for consistency.

Fixes #3 