### PR TITLE
Disable 'once' warning in the IPv6 handling scope

### DIFF
--- a/bin/asql
+++ b/bin/asql
@@ -1528,6 +1528,8 @@ sub parseApacheLogLine
     else
     {
 
+        no warnings 'once';
+
         #
         #  Both available
         #


### PR DESCRIPTION
Fixes #5 