### PR TITLE
Support extra trailing fields in the server log file

### DIFF
--- a/bin/asql
+++ b/bin/asql
@@ -1542,14 +1542,17 @@ sub parseApacheLogLine
 
     my $parse_combined = qr/^ \s*       # Start at the beginning
          $pat_ip_address \s+        # IP address
-         (\S+) \s+                  # Ident
-         (\S+) \s+                  # Userid
+         (\-|\S+) \s+               # Ident or "-"
+         (\-|\S+) \s+               # Userid or "-"
          \[([^\]]*)\] \s+           # Date and time
          $pat_quoted_field \s+      # Request
          (\d+) \s+                  # Status
          (\-|[\d]+) \s+             # Length of reply or "-"
          $pat_quoted_field \s+      # Referer
-         $pat_quoted_field \s*          # User agent
+         $pat_quoted_field \s*      # User agent
+#         (\S+) \s+                  # Server name
+#         $pat_ip_address \s*        # Server IP address
+         (.)*                       # Extra trailing fields
          $                          # End at the end
        /x;
 
@@ -1570,11 +1573,11 @@ sub parseApacheLogLine
         $ref->{ 'agent' } = $9;
         $ref->{ 'refer' } = $8;
 
-        my @Dsplit = split( /\s+/, $ref->{ date } );
-        $ref->{ diffgmt } = $Dsplit[1];
+        my @Dsplit = split( /\s+/, $ref->{ 'date' } );
+        $ref->{ 'diffgmt' } = $Dsplit[1];
         my @Ds2 = split( /\:/, $Dsplit[0], 2 );
-        $ref->{ date } = $Ds2[0];
-        $ref->{ time } = $Ds2[1];
+        $ref->{ 'date' } = $Ds2[0];
+        $ref->{ 'time' } = $Ds2[1];
 
         if ( $ref->{ 'file' } =~ /^([A-Z]+) (.*) HTTP\/([0-9.]+)$/ )
         {


### PR DESCRIPTION
This extends support to somewhat modified combined format (have a server name and IP appended at the end, also have '-' for ident and userid).

```
LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-agent}i\" %V %A" combined

```

Such access log file format is often set up on shared hosting.

This change should be backward compatible with the format originally supported by `asq`, which appears to be Apache webserver Combined Log Format:

```
LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-agent}i\"" combined
```

- [Combined Log Format](https://httpd.apache.org/docs/2.4/logs.html)
- [Custom Log Formats](https://httpd.apache.org/docs/2.4/mod/mod_log_config.html#formats)

- - - -

Fixes #7. Running the `asql` on the [sample access.log](../files/7842438/access.log) attached to the issue properly loads all of the expected records (7):

```
asql --load access.log
Name "Regexp::IPv6::IPv6_re" used only once: possible typo at ../usr/bin/asql line 1534.
asql vUNRELEASED - type 'help' for help.
asql> select count(*) from logs;
7
```
